### PR TITLE
fix typo and add rosdep install in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ Follow this [page](https://coral.withgoogle.com/docs/accelerator/get-started/).
 ```
 mkdir ~/ros/coral_ws/src
 cd ~/ros/coral_ws/src
-git clone git@github.com/knorth55/coral_usb_ros.git
+git clone git@github.com:knorth55/coral_usb_ros.git
 ln -sf ~/ros/coral_ws/src/coral_usb_ros/fc.rosinstall ~/ros/coral_ws/src/.rosinstall
 wstool up
+rosdep install --from-paths . --ignore-src -y -r
 cd ~/ros/coral_ws
 catkin init
 catkin config -DPYTHON_EXECUTABLE=/usr/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/include/python3.5m -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.5m.so


### PR DESCRIPTION
- fix typo of git reposity url in install instruction in README.md
- add "rosdep install" to the instruction.