### PR TITLE
need to source /opt/ros/${ROS_DISTRO}/setup.bash, before source ~/cor…

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ rosrun jsk_perception image_publisher.py _file_name:=$(rospack find jsk_percepti
 
 ```bash
 # source edge tpu workspace
-source ~/coral_ws/devel/setup.bash
+source /opt/ros/${ROS_DISTRO}/setup.bash # THIS IS VERY IMPORTANT FOR MELODIC to set /opt/ros/${ROS_DISTRO}/lib/python2.7/dist-packages in $PYTHONPATH
+source ~/coral_ws/devel/setup.bash       # THIS PUT devel/lib/python3/dist-packages in fornt of /opt/ros/${ROS_DISTRO}/lib/python2.7/dist-package
 # object detector
 roslaunch coral_usb edgetpu_object_detector.launch INPUT_IMAGE:=/image_publisher/output
 # face detector


### PR DESCRIPTION
…al_ws/deve/setup.bash

otherwise we got
```
$ roslaunch
Traceback (most recent call last):
  File "/opt/ros/melodic/bin/roslaunch", line 34, in <module>
    import roslaunch
ImportError: No module named roslaunch
```