### PR TITLE
Support compressed image for both input and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ roslaunch coral_usb edgetpu_human_pose_estimator.launch INPUT_IMAGE:=/image_publ
 roslaunch coral_usb edgetpu_semantic_segmenter.launch INPUT_IMAGE:=/image_publisher/output
 ```
 
+To subscribe compressed input image, use `IMAGE_TRANSPORT:=compressed`
+
+```bash
+roslaunch edgetpu_object_detector.launch INPUT_IMAGE:=/image_publisher/output IMAGE_TRANSPORT:=compressed
+```
+
 ### Run `image_view`
 
 ```bash
@@ -186,6 +192,12 @@ rosrun image_view image_view image:=/edgetpu_face_detector/output/image
 rosrun image_view image_view image:=/edgetpu_human_pose_estimator/output/image
 # semantic segmenter
 rosrun image_view image_view image:=/edgetpu_semantic_segmenter/output/image
+```
+
+To subscribe compressed output image, set `~image_transport` param to `compressed`
+
+```bash
+rosrun image_view image_view image:=/edgetpu_object_detector/output/image _image_transport:=compressed
 ```
 
 ## ROS node information
@@ -235,6 +247,10 @@ rosrun image_view image_view image:=/edgetpu_semantic_segmenter/output/image
 - `~visualize_duration` (`Float`, default: `0.1`)
 
   - Time duration for visualization
+
+- `~image_transport:` (`String`, default: `raw`)
+
+  - Set `compressed` to subscribe compressed image
 
 #### Dynamic parameters
 
@@ -288,6 +304,10 @@ rosrun image_view image_view image:=/edgetpu_semantic_segmenter/output/image
 
   - Time duration for visualization
 
+- `~image_transport:` (`String`, default: `raw`)
+
+  - Set `compressed` to subscribe compressed image
+
 #### Dynamic parameters
 
 - `~score_thresh`: (`Float`, default: `0.6`)
@@ -335,6 +355,10 @@ rosrun image_view image_view image:=/edgetpu_semantic_segmenter/output/image
 - `~visualize_duration` (`Float`, default: `0.1`)
 
   - Time duration for visualization
+
+- `~image_transport:` (`String`, default: `raw`)
+
+  - Set `compressed` to subscribe compressed image
 
 #### Dynamic parameters
 
@@ -387,3 +411,7 @@ rosrun image_view image_view image:=/edgetpu_semantic_segmenter/output/image
 - `~visualize_duration` (`Float`, default: `0.1`)
 
   - Time duration for visualization
+
+- `~image_transport:` (`String`, default: `raw`)
+
+  - Set `compressed` to subscribe compressed image

--- a/launch/edgetpu_face_detector.launch
+++ b/launch/edgetpu_face_detector.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="INPUT_IMAGE"/>
+  <arg name="IMAGE_TRANSPORT" default="raw"/>
   <arg name="model_file" default="$(find coral_usb)/models/mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite"/>
 
   <node name="edgetpu_face_detector"
@@ -8,6 +9,7 @@
     <remap from="~input" to="$(arg INPUT_IMAGE)" />
     <rosparam subst_value="true" >
       model_file: $(arg model_file)
+      image_transport: $(arg IMAGE_TRANSPORT)
     </rosparam>
   </node>
 </launch>

--- a/launch/edgetpu_human_pose_estimator.launch
+++ b/launch/edgetpu_human_pose_estimator.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="INPUT_IMAGE"/>
+  <arg name="IMAGE_TRANSPORT" default="raw"/>
   <arg name="model_file" default="$(find coral_usb)/python/coral_usb/posenet/models/mobilenet/posenet_mobilenet_v1_075_481_641_quant_decoder_edgetpu.tflite"/>
 
   <node name="edgetpu_human_pose_estimator"
@@ -8,6 +9,7 @@
     <remap from="~input" to="$(arg INPUT_IMAGE)" />
     <rosparam subst_value="true" >
       model_file: $(arg model_file)
+      image_transport: $(arg IMAGE_TRANSPORT)
     </rosparam>
   </node>
 </launch>

--- a/launch/edgetpu_object_detector.launch
+++ b/launch/edgetpu_object_detector.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="INPUT_IMAGE"/>
+  <arg name="IMAGE_TRANSPORT" default="raw"/>
   <arg name="model_file" default="$(find coral_usb)/models/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite"/>
   <arg name="label_file" default="$(find coral_usb)/models/coco_labels.txt"/>
 
@@ -10,6 +11,7 @@
     <rosparam subst_value="true" >
       model_file: $(arg model_file)
       label_file: $(arg label_file)
+      image_transport: $(arg IMAGE_TRANSPORT)
     </rosparam>
   </node>
 </launch>

--- a/launch/edgetpu_semantic_segmenter.launch
+++ b/launch/edgetpu_semantic_segmenter.launch
@@ -1,9 +1,13 @@
 <launch>
   <arg name="INPUT_IMAGE"/>
+  <arg name="IMAGE_TRANSPORT" default="raw"/>
 
   <node name="edgetpu_semantic_segmenter"
         pkg="coral_usb" type="edgetpu_semantic_segmenter.py"
         output="screen" respawn="true">
     <remap from="~input" to="$(arg INPUT_IMAGE)" />
+    <rosparam subst_value="true" >
+      image_transport: $(arg IMAGE_TRANSPORT)
+    </rosparam>
   </node>
 </launch>

--- a/node_scripts/edgetpu_face_detector.py
+++ b/node_scripts/edgetpu_face_detector.py
@@ -27,7 +27,8 @@ from jsk_recognition_msgs.msg import ClassificationResult
 from jsk_recognition_msgs.msg import Rect
 from jsk_recognition_msgs.msg import RectArray
 from jsk_topic_tools import ConnectionBasedTransport
-from sensor_msgs.msg import Image, CompressedImage
+from sensor_msgs.msg import CompressedImage
+from sensor_msgs.msg import Image
 
 from coral_usb.cfg import EdgeTPUFaceDetectorConfig
 

--- a/node_scripts/edgetpu_face_detector.py
+++ b/node_scripts/edgetpu_face_detector.py
@@ -27,7 +27,7 @@ from jsk_recognition_msgs.msg import ClassificationResult
 from jsk_recognition_msgs.msg import Rect
 from jsk_recognition_msgs.msg import RectArray
 from jsk_topic_tools import ConnectionBasedTransport
-from sensor_msgs.msg import Image
+from sensor_msgs.msg import Image, CompressedImage
 
 from coral_usb.cfg import EdgeTPUFaceDetectorConfig
 
@@ -35,6 +35,10 @@ from coral_usb.cfg import EdgeTPUFaceDetectorConfig
 class EdgeTPUFaceDetector(ConnectionBasedTransport):
 
     def __init__(self):
+        # get image_trasport before ConnectionBasedTransport subscribes ~input
+        self.transport_hint = rospy.get_param('~image_transport', 'raw')
+        rospy.loginfo("Using transport {}".format(self.transport_hint))
+        #
         super(EdgeTPUFaceDetector, self).__init__()
         rospack = rospkg.RosPack()
         pkg_path = rospack.get_path('coral_usb')
@@ -67,6 +71,8 @@ class EdgeTPUFaceDetector(ConnectionBasedTransport):
             self.lock = threading.Lock()
             self.pub_image = self.advertise(
                 '~output/image', Image, queue_size=1)
+            self.pub_image_compressed = self.advertise(
+                '~output/image/compressed', CompressedImage, queue_size=1)
             self.timer = rospy.Timer(
                 rospy.Duration(duration), self.visualize_cb)
             self.img = None
@@ -76,15 +82,21 @@ class EdgeTPUFaceDetector(ConnectionBasedTransport):
             self.scores = None
 
     def subscribe(self):
-        self.sub_image = rospy.Subscriber(
-            '~input', Image, self.image_cb, queue_size=1, buff_size=2**26)
+        if self.transport_hint == 'compressed':
+            self.sub_image = rospy.Subscriber(
+                '{}/compressed'.format(rospy.resolve_name('~input')),
+                CompressedImage, self.image_cb, queue_size=1, buff_size=2**26)
+        else:
+            self.sub_image = rospy.Subscriber(
+                '~input', Image, self.image_cb, queue_size=1, buff_size=2**26)
 
     def unsubscribe(self):
         self.sub_image.unregister()
 
     @property
     def visualize(self):
-        return self.pub_image.get_num_connections() > 0
+        return self.pub_image.get_num_connections() > 0 or \
+            self.pub_image_compressed.get_num_connections() > 0
 
     def config_callback(self, config, level):
         self.score_thresh = config.score_thresh
@@ -92,7 +104,11 @@ class EdgeTPUFaceDetector(ConnectionBasedTransport):
         return config
 
     def image_cb(self, msg):
-        img = self.bridge.imgmsg_to_cv2(msg, desired_encoding='rgb8')
+        if self.transport_hint == 'compressed':
+            np_arr = np.fromstring(msg.data, np.uint8)
+            img = cv2.imdecode(np_arr, cv2.IMREAD_COLOR)
+        else:
+            img = self.bridge.imgmsg_to_cv2(msg, desired_encoding='rgb8')
         H, W = img.shape[:2]
         objs = self.engine.DetectWithImage(
             PIL.Image.fromarray(img), threshold=self.score_thresh,
@@ -166,11 +182,21 @@ class EdgeTPUFaceDetector(ConnectionBasedTransport):
         vis_img.shape = (h, w, 3)
         fig.clf()
         plt.close()
-        vis_msg = self.bridge.cv2_to_imgmsg(vis_img, 'rgb8')
-        # BUG: https://answers.ros.org/question/316362/sensor_msgsimage-generates-float-instead-of-int-with-python3/  # NOQA
-        vis_msg.step = int(vis_msg.step)
-        vis_msg.header = header
-        self.pub_image.publish(vis_msg)
+        if self.pub_image.get_num_connections() > 0:
+            vis_msg = self.bridge.cv2_to_imgmsg(vis_img, 'rgb8')
+            # BUG: https://answers.ros.org/question/316362/sensor_msgsimage-generates-float-instead-of-int-with-python3/  # NOQA
+            vis_msg.step = int(vis_msg.step)
+            vis_msg.header = header
+            self.pub_image.publish(vis_msg)
+        if self.pub_image_compressed.get_num_connections() > 0:
+            # publish compressed http://wiki.ros.org/rospy_tutorials/Tutorials/WritingImagePublisherSubscriber  # NOQA
+            vis_compressed_msg = CompressedImage()
+            vis_compressed_msg.header = header
+            vis_compressed_msg.format = "jpeg"
+            vis_img_rgb = cv2.cvtColor(vis_img, cv2.COLOR_BGR2RGB)
+            vis_compressed_msg.data = np.array(
+                cv2.imencode('.jpg', vis_img_rgb)[1]).tostring()
+            self.pub_image_compressed.publish(vis_compressed_msg)
 
 
 if __name__ == '__main__':

--- a/node_scripts/edgetpu_human_pose_estimator.py
+++ b/node_scripts/edgetpu_human_pose_estimator.py
@@ -26,7 +26,7 @@ from geometry_msgs.msg import Pose
 from jsk_recognition_msgs.msg import PeoplePose
 from jsk_recognition_msgs.msg import PeoplePoseArray
 from jsk_topic_tools import ConnectionBasedTransport
-from sensor_msgs.msg import Image
+from sensor_msgs.msg import Image, CompressedImage
 
 from coral_usb.cfg import EdgeTPUHumanPoseEstimatorConfig
 from coral_usb import PoseEngine
@@ -35,6 +35,10 @@ from coral_usb import PoseEngine
 class EdgeTPUHumanPoseEstimator(ConnectionBasedTransport):
 
     def __init__(self):
+        # get image_trasport before ConnectionBasedTransport subscribes ~input
+        self.transport_hint = rospy.get_param('~image_transport', 'raw')
+        rospy.loginfo("Using transport {}".format(self.transport_hint))
+        #
         super(EdgeTPUHumanPoseEstimator, self).__init__()
         rospack = rospkg.RosPack()
         pkg_path = rospack.get_path('coral_usb')
@@ -66,6 +70,8 @@ class EdgeTPUHumanPoseEstimator(ConnectionBasedTransport):
             self.lock = threading.Lock()
             self.pub_image = self.advertise(
                 '~output/image', Image, queue_size=1)
+            self.pub_image_compressed = self.advertise(
+                '~output/image/compressed', CompressedImage, queue_size=1)
             self.timer = rospy.Timer(
                 rospy.Duration(duration), self.visualize_cb)
             self.img = None
@@ -73,15 +79,21 @@ class EdgeTPUHumanPoseEstimator(ConnectionBasedTransport):
             self.points = None
 
     def subscribe(self):
-        self.sub_image = rospy.Subscriber(
-            '~input', Image, self.image_cb, queue_size=1, buff_size=2**26)
+        if self.transport_hint == 'compressed':
+            self.sub_image = rospy.Subscriber(
+                '{}/compressed'.format(rospy.resolve_name('~input')),
+                CompressedImage, self.image_cb, queue_size=1, buff_size=2**26)
+        else:
+            self.sub_image = rospy.Subscriber(
+                '~input', Image, self.image_cb, queue_size=1, buff_size=2**26)
 
     def unsubscribe(self):
         self.sub_image.unregister()
 
     @property
     def visualize(self):
-        return self.pub_image.get_num_connections() > 0
+        return self.pub_image.get_num_connections() > 0 or \
+            self.pub_image_compressed.get_num_connections() > 0
 
     def config_callback(self, config, level):
         self.score_thresh = config.score_thresh
@@ -89,7 +101,11 @@ class EdgeTPUHumanPoseEstimator(ConnectionBasedTransport):
         return config
 
     def image_cb(self, msg):
-        img = self.bridge.imgmsg_to_cv2(msg, desired_encoding='rgb8')
+        if self.transport_hint == 'compressed':
+            np_arr = np.fromstring(msg.data, np.uint8)
+            img = cv2.imdecode(np_arr, cv2.IMREAD_COLOR)
+        else:
+            img = self.bridge.imgmsg_to_cv2(msg, desired_encoding='rgb8')
         resized_img = cv2.resize(img, (self.resized_W, self.resized_H))
         H, W, _ = img.shape
         y_scale = self.resized_H / H
@@ -156,11 +172,21 @@ class EdgeTPUHumanPoseEstimator(ConnectionBasedTransport):
         vis_img.shape = (h, w, 3)
         fig.clf()
         plt.close()
-        vis_msg = self.bridge.cv2_to_imgmsg(vis_img, 'rgb8')
-        # BUG: https://answers.ros.org/question/316362/sensor_msgsimage-generates-float-instead-of-int-with-python3/  # NOQA
-        vis_msg.step = int(vis_msg.step)
-        vis_msg.header = header
-        self.pub_image.publish(vis_msg)
+        if self.pub_image.get_num_connections() > 0:
+            vis_msg = self.bridge.cv2_to_imgmsg(vis_img, 'rgb8')
+            # BUG: https://answers.ros.org/question/316362/sensor_msgsimage-generates-float-instead-of-int-with-python3/  # NOQA
+            vis_msg.step = int(vis_msg.step)
+            vis_msg.header = header
+            self.pub_image.publish(vis_msg)
+        if self.pub_image_compressed.get_num_connections() > 0:
+            # publish compressed http://wiki.ros.org/rospy_tutorials/Tutorials/WritingImagePublisherSubscriber  # NOQA
+            vis_compressed_msg = CompressedImage()
+            vis_compressed_msg.header = header
+            vis_compressed_msg.format = "jpeg"
+            vis_img_rgb = cv2.cvtColor(vis_img, cv2.COLOR_BGR2RGB)
+            vis_compressed_msg.data = np.array(
+                cv2.imencode('.jpg', vis_img_rgb)[1]).tostring()
+            self.pub_image_compressed.publish(vis_compressed_msg)
 
 
 if __name__ == '__main__':

--- a/node_scripts/edgetpu_human_pose_estimator.py
+++ b/node_scripts/edgetpu_human_pose_estimator.py
@@ -26,7 +26,8 @@ from geometry_msgs.msg import Pose
 from jsk_recognition_msgs.msg import PeoplePose
 from jsk_recognition_msgs.msg import PeoplePoseArray
 from jsk_topic_tools import ConnectionBasedTransport
-from sensor_msgs.msg import Image, CompressedImage
+from sensor_msgs.msg import CompressedImage
+from sensor_msgs.msg import Image
 
 from coral_usb.cfg import EdgeTPUHumanPoseEstimatorConfig
 from coral_usb import PoseEngine

--- a/node_scripts/edgetpu_object_detector.py
+++ b/node_scripts/edgetpu_object_detector.py
@@ -28,7 +28,8 @@ from jsk_recognition_msgs.msg import ClassificationResult
 from jsk_recognition_msgs.msg import Rect
 from jsk_recognition_msgs.msg import RectArray
 from jsk_topic_tools import ConnectionBasedTransport
-from sensor_msgs.msg import Image, CompressedImage
+from sensor_msgs.msg import CompressedImage
+from sensor_msgs.msg import Image
 
 from coral_usb.cfg import EdgeTPUObjectDetectorConfig
 

--- a/node_scripts/edgetpu_object_detector.py
+++ b/node_scripts/edgetpu_object_detector.py
@@ -28,7 +28,7 @@ from jsk_recognition_msgs.msg import ClassificationResult
 from jsk_recognition_msgs.msg import Rect
 from jsk_recognition_msgs.msg import RectArray
 from jsk_topic_tools import ConnectionBasedTransport
-from sensor_msgs.msg import Image
+from sensor_msgs.msg import Image, CompressedImage
 
 from coral_usb.cfg import EdgeTPUObjectDetectorConfig
 
@@ -36,6 +36,10 @@ from coral_usb.cfg import EdgeTPUObjectDetectorConfig
 class EdgeTPUObjectDetector(ConnectionBasedTransport):
 
     def __init__(self):
+        # get image_trasport before ConnectionBasedTransport subscribes ~input
+        self.transport_hint = rospy.get_param('~image_transport', 'raw')
+        rospy.loginfo("Using transport {}".format(self.transport_hint))
+        #
         super(EdgeTPUObjectDetector, self).__init__()
         rospack = rospkg.RosPack()
         pkg_path = rospack.get_path('coral_usb')
@@ -68,6 +72,8 @@ class EdgeTPUObjectDetector(ConnectionBasedTransport):
             self.lock = threading.Lock()
             self.pub_image = self.advertise(
                 '~output/image', Image, queue_size=1)
+            self.pub_image_compressed = self.advertise(
+                '~output/image/compressed', CompressedImage, queue_size=1)
             self.timer = rospy.Timer(
                 rospy.Duration(duration), self.visualize_cb)
             self.img = None
@@ -77,15 +83,21 @@ class EdgeTPUObjectDetector(ConnectionBasedTransport):
             self.scores = None
 
     def subscribe(self):
-        self.sub_image = rospy.Subscriber(
-            '~input', Image, self.image_cb, queue_size=1, buff_size=2**26)
+        if self.transport_hint == 'compressed':
+            self.sub_image = rospy.Subscriber(
+                '{}/compressed'.format(rospy.resolve_name('~input')),
+                CompressedImage, self.image_cb, queue_size=1, buff_size=2**26)
+        else:
+            self.sub_image = rospy.Subscriber(
+                '~input', Image, self.image_cb, queue_size=1, buff_size=2**26)
 
     def unsubscribe(self):
         self.sub_image.unregister()
 
     @property
     def visualize(self):
-        return self.pub_image.get_num_connections() > 0
+        return self.pub_image.get_num_connections() > 0 or \
+            self.pub_image_compressed.get_num_connections() > 0
 
     def config_callback(self, config, level):
         self.score_thresh = config.score_thresh
@@ -100,7 +112,11 @@ class EdgeTPUObjectDetector(ConnectionBasedTransport):
             return list(labels.keys()), list(labels.values())
 
     def image_cb(self, msg):
-        img = self.bridge.imgmsg_to_cv2(msg, desired_encoding='rgb8')
+        if self.transport_hint == 'compressed':
+            np_arr = np.fromstring(msg.data, np.uint8)
+            img = cv2.imdecode(np_arr, cv2.IMREAD_COLOR)
+        else:
+            img = self.bridge.imgmsg_to_cv2(msg, desired_encoding='rgb8')
         H, W = img.shape[:2]
         objs = self.engine.DetectWithImage(
             PIL.Image.fromarray(img), threshold=self.score_thresh,
@@ -176,11 +192,21 @@ class EdgeTPUObjectDetector(ConnectionBasedTransport):
         vis_img.shape = (h, w, 3)
         fig.clf()
         plt.close()
-        vis_msg = self.bridge.cv2_to_imgmsg(vis_img, 'rgb8')
-        # BUG: https://answers.ros.org/question/316362/sensor_msgsimage-generates-float-instead-of-int-with-python3/  # NOQA
-        vis_msg.step = int(vis_msg.step)
-        vis_msg.header = header
-        self.pub_image.publish(vis_msg)
+        if self.pub_image.get_num_connections() > 0:
+            vis_msg = self.bridge.cv2_to_imgmsg(vis_img, 'rgb8')
+            # BUG: https://answers.ros.org/question/316362/sensor_msgsimage-generates-float-instead-of-int-with-python3/  # NOQA
+            vis_msg.step = int(vis_msg.step)
+            vis_msg.header = header
+            self.pub_image.publish(vis_msg)
+        if self.pub_image_compressed.get_num_connections() > 0:
+            # publish compressed http://wiki.ros.org/rospy_tutorials/Tutorials/WritingImagePublisherSubscriber  # NOQA
+            vis_compressed_msg = CompressedImage()
+            vis_compressed_msg.header = header
+            vis_compressed_msg.format = "jpeg"
+            vis_img_rgb = cv2.cvtColor(vis_img, cv2.COLOR_BGR2RGB)
+            vis_compressed_msg.data = np.array(
+                cv2.imencode('.jpg', vis_img_rgb)[1]).tostring()
+            self.pub_image_compressed.publish(vis_compressed_msg)
 
 
 if __name__ == '__main__':

--- a/node_scripts/edgetpu_semantic_segmenter.py
+++ b/node_scripts/edgetpu_semantic_segmenter.py
@@ -22,7 +22,8 @@ import rospkg
 import rospy
 
 from jsk_topic_tools import ConnectionBasedTransport
-from sensor_msgs.msg import Image, CompressedImage
+from sensor_msgs.msg import CompressedImage
+from sensor_msgs.msg import Image
 
 
 class EdgeTPUSemanticSegmenter(ConnectionBasedTransport):

--- a/node_scripts/edgetpu_semantic_segmenter.py
+++ b/node_scripts/edgetpu_semantic_segmenter.py
@@ -22,12 +22,16 @@ import rospkg
 import rospy
 
 from jsk_topic_tools import ConnectionBasedTransport
-from sensor_msgs.msg import Image
+from sensor_msgs.msg import Image, CompressedImage
 
 
 class EdgeTPUSemanticSegmenter(ConnectionBasedTransport):
 
     def __init__(self):
+        # get image_trasport before ConnectionBasedTransport subscribes ~input
+        self.transport_hint = rospy.get_param('~image_transport', 'raw')
+        rospy.loginfo("Using transport {}".format(self.transport_hint))
+        #
         super(EdgeTPUSemanticSegmenter, self).__init__()
         rospack = rospkg.RosPack()
         pkg_path = rospack.get_path('coral_usb')
@@ -82,6 +86,8 @@ class EdgeTPUSemanticSegmenter(ConnectionBasedTransport):
             self.lock = threading.Lock()
             self.pub_image = self.advertise(
                 '~output/image', Image, queue_size=1)
+            self.pub_image_compressed = self.advertise(
+                '~output/image/compressed', CompressedImage, queue_size=1)
             self.timer = rospy.Timer(
                 rospy.Duration(duration), self.visualize_cb)
             self.img = None
@@ -89,15 +95,21 @@ class EdgeTPUSemanticSegmenter(ConnectionBasedTransport):
             self.label = None
 
     def subscribe(self):
-        self.sub_image = rospy.Subscriber(
-            '~input', Image, self.image_cb, queue_size=1, buff_size=2**26)
+        if self.transport_hint == 'compressed':
+            self.sub_image = rospy.Subscriber(
+                '{}/compressed'.format(rospy.resolve_name('~input')),
+                CompressedImage, self.image_cb, queue_size=1, buff_size=2**26)
+        else:
+            self.sub_image = rospy.Subscriber(
+                '~input', Image, self.image_cb, queue_size=1, buff_size=2**26)
 
     def unsubscribe(self):
         self.sub_image.unregister()
 
     @property
     def visualize(self):
-        return self.pub_image.get_num_connections() > 0
+        return self.pub_image.get_num_connections() > 0 or \
+            self.pub_image_compressed.get_num_connections() > 0
 
     def config_callback(self, config, level):
         self.score_thresh = config.score_thresh
@@ -112,7 +124,11 @@ class EdgeTPUSemanticSegmenter(ConnectionBasedTransport):
             return list(labels.keys()), list(labels.values())
 
     def image_cb(self, msg):
-        img = self.bridge.imgmsg_to_cv2(msg, desired_encoding='rgb8')
+        if self.transport_hint == 'compressed':
+            np_arr = np.fromstring(msg.data, np.uint8)
+            img = cv2.imdecode(np_arr, cv2.IMREAD_COLOR)
+        else:
+            img = self.bridge.imgmsg_to_cv2(msg, desired_encoding='rgb8')
         H, W = img.shape[:2]
         input_H, input_W = self.input_shape
         input_tensor = cv2.resize(img, (input_W, input_H))
@@ -161,11 +177,21 @@ class EdgeTPUSemanticSegmenter(ConnectionBasedTransport):
         vis_img.shape = (h, w, 3)
         fig.clf()
         plt.close()
-        vis_msg = self.bridge.cv2_to_imgmsg(vis_img, 'rgb8')
-        # BUG: https://answers.ros.org/question/316362/sensor_msgsimage-generates-float-instead-of-int-with-python3/  # NOQA
-        vis_msg.step = int(vis_msg.step)
-        vis_msg.header = header
-        self.pub_image.publish(vis_msg)
+        if self.pub_image.get_num_connections() > 0:
+            vis_msg = self.bridge.cv2_to_imgmsg(vis_img, 'rgb8')
+            # BUG: https://answers.ros.org/question/316362/sensor_msgsimage-generates-float-instead-of-int-with-python3/  # NOQA
+            vis_msg.step = int(vis_msg.step)
+            vis_msg.header = header
+            self.pub_image.publish(vis_msg)
+        if self.pub_image_compressed.get_num_connections() > 0:
+            # publish compressed http://wiki.ros.org/rospy_tutorials/Tutorials/WritingImagePublisherSubscriber  # NOQA
+            vis_compressed_msg = CompressedImage()
+            vis_compressed_msg.header = header
+            vis_compressed_msg.format = "jpeg"
+            vis_img_rgb = cv2.cvtColor(vis_img, cv2.COLOR_BGR2RGB)
+            vis_compressed_msg.data = np.array(
+                cv2.imencode('.jpg', vis_img_rgb)[1]).tostring()
+            self.pub_image_compressed.publish(vis_compressed_msg)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
```
roslaunch edgetpu_object_detector.launch INPUT_IMAGE:=/image_publisher/output IMAGE_TRANSPORT:=compressed
rosrun image_view image_view image:=/edgetpu_object_detector/output/image _image_transport:=compressed
```

- add documentation for compressed transport
- support compressed images, support IMAGE_TRANSPORT ros-args to launch  files, publish compressed topic

raw:
![rosgraph-raw](https://user-images.githubusercontent.com/493276/101662021-54f35e00-3a8c-11eb-89aa-e8bf9fb98af1.png)

compressed:
![rosgraph-compressed](https://user-images.githubusercontent.com/493276/101662032-56bd2180-3a8c-11eb-820f-d7c33e00be67.png)


note : use `rosparam set enable_statistics true` to visualize statistics in `ros_graph` http://wiki.ros.org/rqt_graph

Used https://github.com/ros-visualization/rqt_graph/pull/57 to show bytes/msg