### PR TITLE
Change the way model file (and label file) are loaded for object detector and face detector 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 models/
+*__pycache__

--- a/README.md
+++ b/README.md
@@ -242,14 +242,6 @@ rosrun image_view image_view image:=/edgetpu_object_detector/output/image _image
 
   - Classifier name
 
-- `~model_file` (`String`, default: `$(rospack find coral_usb)/models/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite`)
-
-  - Model file path
-
-- `~label_file` (`String`, default: `$(rospack find coral_usb)/models/coco_labels.txt`)
-
-  - Label file path.
-
 - `~enable_visualization` (`Bool`, default: `True`)
 
   - Whether enable visualization or not
@@ -271,6 +263,14 @@ rosrun image_view image_view image:=/edgetpu_object_detector/output/image _image
 - `~top_k`: (`Int`, default: `100`)
 
   - Maximum number of detected objects
+
+- `~model_file` (`String`, default: `$(rospack find coral_usb)/models/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite`)
+
+  - Model file path
+
+- `~label_file` (`String`, default: `$(rospack find coral_usb)/models/coco_labels.txt`)
+
+  - Label file path.
 
 ### Face detector: `edgetpu_face_detector.py`
 

--- a/README.md
+++ b/README.md
@@ -302,10 +302,6 @@ rosrun image_view image_view image:=/edgetpu_object_detector/output/image _image
 
   - Classifier name
 
-- `~model_file` (`String`, default: `$(rospack find coral_usb)/models/mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite`)
-
-  - Model file path
-
 - `~enable_visualization` (`Bool`, default: `True`)
 
   - Whether enable visualization or not
@@ -327,6 +323,10 @@ rosrun image_view image_view image:=/edgetpu_object_detector/output/image _image
 - `~top_k`: (`Int`, default: `100`)
 
   - Maximum number of detected faces
+
+- `~model_file` (`String`, default: `$(rospack find coral_usb)/models/mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite`)
+
+  - Model file path
 
 ### Human pose estimator: `edgetpu_human_pose_estimator.py`
 

--- a/README.md
+++ b/README.md
@@ -264,11 +264,11 @@ rosrun image_view image_view image:=/edgetpu_object_detector/output/image _image
 
   - Maximum number of detected objects
 
-- `~model_file` (`String`, default: `$(rospack find coral_usb)/models/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite`)
+- `~model_file` (`String`, default: `package://coral_usb/models/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite`)
 
   - Model file path
 
-- `~label_file` (`String`, default: `$(rospack find coral_usb)/models/coco_labels.txt`)
+- `~label_file` (`String`, default: `package://coral_usb/models/coco_labels.txt`)
 
   - Label file path.
 
@@ -324,7 +324,7 @@ rosrun image_view image_view image:=/edgetpu_object_detector/output/image _image
 
   - Maximum number of detected faces
 
-- `~model_file` (`String`, default: `$(rospack find coral_usb)/models/mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite`)
+- `~model_file` (`String`, default: `package://coral_usb/models/mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite`)
 
   - Model file path
 

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ rosrun image_view image_view image:=/edgetpu_object_detector/output/image _image
 
   - Classifier name
 
-- `~model_file` (`String`, default: `$(rospack find coral_usb)/python/coral_usb/posenet/models/posenet_mobilenet_v1_075_481_641_quant_decoder_edgetpu.tflite`)
+- `~model_file` (`String`, default: `package://coral_usb/python/coral_usb/posenet/models/posenet_mobilenet_v1_075_481_641_quant_decoder_edgetpu.tflite`)
 
   - Model file path
 
@@ -414,7 +414,7 @@ rosrun image_view image_view image:=/edgetpu_object_detector/output/image _image
 
   - Classifier name
 
-- `~model_file` (`String`, default: `$(rospack find coral_usb)/models/deeplabv3_mnv2_pascal_quant_edgetpu.tflite`)
+- `~model_file` (`String`, default: `package://coral_usb/models/deeplabv3_mnv2_pascal_quant_edgetpu.tflite`)
 
   - Model file path
 

--- a/cfg/EdgeTPUFaceDetector.cfg
+++ b/cfg/EdgeTPUFaceDetector.cfg
@@ -1,20 +1,13 @@
 #!/usr/bin/env python
-import rospkg
 
 PACKAGE = 'coral_usb'
 
 from dynamic_reconfigure.parameter_generator_catkin import *
 
-rospack = rospkg.RosPack()
-pkg_path = rospack.get_path('coral_usb')
-model_file = os.path.join(
-    pkg_path,
-    './models/mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite')
-
 gen = ParameterGenerator()
 
 gen.add('score_thresh', double_t, 0, 'Threshold for confidence score', 0.60, 0.0, 1.0)
 gen.add('top_k', int_t, 0, 'Threshold for confidence score', 100, 0, 1000)
-gen.add('model_file', str_t, 0, 'Model file path', model_file)
+gen.add('model_file', str_t, 0, 'Model file path', 'package://coral_usb/models/mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite')
 
 exit(gen.generate(PACKAGE, PACKAGE, 'EdgeTPUFaceDetector'))

--- a/cfg/EdgeTPUFaceDetector.cfg
+++ b/cfg/EdgeTPUFaceDetector.cfg
@@ -1,12 +1,20 @@
 #!/usr/bin/env python
+import rospkg
 
 PACKAGE = 'coral_usb'
 
 from dynamic_reconfigure.parameter_generator_catkin import *
 
+rospack = rospkg.RosPack()
+pkg_path = rospack.get_path('coral_usb')
+model_file = os.path.join(
+    pkg_path,
+    './models/mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite')
+
 gen = ParameterGenerator()
 
 gen.add('score_thresh', double_t, 0, 'Threshold for confidence score', 0.60, 0.0, 1.0)
 gen.add('top_k', int_t, 0, 'Threshold for confidence score', 100, 0, 1000)
+gen.add('model_file', str_t, 0, 'Model file path', model_file)
 
 exit(gen.generate(PACKAGE, PACKAGE, 'EdgeTPUFaceDetector'))

--- a/cfg/EdgeTPUObjectDetector.cfg
+++ b/cfg/EdgeTPUObjectDetector.cfg
@@ -1,12 +1,23 @@
 #!/usr/bin/env python
 
+import rospkg
+
 PACKAGE = 'coral_usb'
 
 from dynamic_reconfigure.parameter_generator_catkin import *
+
+rospack = rospkg.RosPack()
+pkg_path = rospack.get_path('coral_usb')
+model_file = os.path.join(
+    pkg_path,
+    './models/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite')
+label_file = os.path.join(pkg_path, './models/coco_labels.txt')
 
 gen = ParameterGenerator()
 
 gen.add('score_thresh', double_t, 0, 'Threshold for confidence score', 0.60, 0.0, 1.0)
 gen.add('top_k', int_t, 0, 'Threshold for confidence score', 100, 0, 1000)
+gen.add('model_file', str_t, 0, 'Model file path', model_file)
+gen.add('label_file', str_t, 0, 'Label file path', label_file)
 
 exit(gen.generate(PACKAGE, PACKAGE, 'EdgeTPUObjectDetector'))

--- a/cfg/EdgeTPUObjectDetector.cfg
+++ b/cfg/EdgeTPUObjectDetector.cfg
@@ -1,23 +1,14 @@
 #!/usr/bin/env python
 
-import rospkg
-
 PACKAGE = 'coral_usb'
 
 from dynamic_reconfigure.parameter_generator_catkin import *
-
-rospack = rospkg.RosPack()
-pkg_path = rospack.get_path('coral_usb')
-model_file = os.path.join(
-    pkg_path,
-    './models/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite')
-label_file = os.path.join(pkg_path, './models/coco_labels.txt')
 
 gen = ParameterGenerator()
 
 gen.add('score_thresh', double_t, 0, 'Threshold for confidence score', 0.60, 0.0, 1.0)
 gen.add('top_k', int_t, 0, 'Threshold for confidence score', 100, 0, 1000)
-gen.add('model_file', str_t, 0, 'Model file path', model_file)
-gen.add('label_file', str_t, 0, 'Label file path', label_file)
+gen.add('model_file', str_t, 0, 'Model file path', 'package://coral_usb/models/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite')
+gen.add('label_file', str_t, 0, 'Label file path', 'package://coral_usb/models/coco_labels.txt')
 
 exit(gen.generate(PACKAGE, PACKAGE, 'EdgeTPUObjectDetector'))

--- a/python/coral_usb/detector_base.py
+++ b/python/coral_usb/detector_base.py
@@ -124,13 +124,12 @@ class EdgeTPUDetectorBase(ConnectionBasedTransport):
         self.score_thresh = config.score_thresh
         self.top_k = config.top_k
         self.model_file = config.model_file
-        self.label_file = config.label_file
-        self.engine = DetectionEngine(self.model_file, device_path=self.device_path)
-        if self.label_file is None:
-            self.label_ids = None
-            self.label_names = None
-        else:
+        try:
+            self.label_file = config.label_file
             self.label_ids, self.label_names = self._load_labels(self.label_file)
+        except:
+            self.label_file = None
+        self.engine = DetectionEngine(self.model_file, device_path=self.device_path)
         return config
 
     def _load_labels(self, path):

--- a/python/coral_usb/detector_base.py
+++ b/python/coral_usb/detector_base.py
@@ -65,13 +65,7 @@ class EdgeTPUDetectorBase(ConnectionBasedTransport):
                 rospy.logwarn(
                     'device {} is already assigned: {}'.format(
                         device_id, device_path))
-
-        self.engine = DetectionEngine(self.model_file, device_path=device_path)
-        if label_file is None:
-            self.label_ids = None
-            self.label_names = None
-        else:
-            self.label_ids, self.label_names = self._load_labels(label_file)
+        self.device_path = device_path
 
         self.pub_rects = self.advertise(
             namespace + 'output/rects', RectArray, queue_size=1)
@@ -129,6 +123,14 @@ class EdgeTPUDetectorBase(ConnectionBasedTransport):
     def config_callback(self, config, level):
         self.score_thresh = config.score_thresh
         self.top_k = config.top_k
+        self.model_file = config.model_file
+        self.label_file = config.label_file
+        self.engine = DetectionEngine(self.model_file, device_path=self.device_path)
+        if self.label_file is None:
+            self.label_ids = None
+            self.label_names = None
+        else:
+            self.label_ids, self.label_names = self._load_labels(self.label_file)
         return config
 
     def _load_labels(self, path):

--- a/python/coral_usb/face_detector.py
+++ b/python/coral_usb/face_detector.py
@@ -1,7 +1,6 @@
 import os
 
 from dynamic_reconfigure.server import Server
-import rospkg
 
 from coral_usb.cfg import EdgeTPUFaceDetectorConfig
 from coral_usb.detector_base import EdgeTPUDetectorBase
@@ -10,12 +9,7 @@ from coral_usb.detector_base import EdgeTPUPanoramaDetectorBase
 
 class EdgeTPUFaceDetector(EdgeTPUDetectorBase):
     def __init__(self, namespace='~'):
-        rospack = rospkg.RosPack()
-        pkg_path = rospack.get_path('coral_usb')
-        model_file = os.path.join(
-            pkg_path,
-            './models/mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite')
-        super(EdgeTPUFaceDetector, self).__init__(model_file, None, namespace)
+        super(EdgeTPUFaceDetector, self).__init__(None, namespace)
 
         # only for human face
         self.label_ids = [0]
@@ -32,13 +26,7 @@ class EdgeTPUFaceDetector(EdgeTPUDetectorBase):
 
 class EdgeTPUPanoramaFaceDetector(EdgeTPUPanoramaDetectorBase):
     def __init__(self, namespace='~'):
-        rospack = rospkg.RosPack()
-        pkg_path = rospack.get_path('coral_usb')
-        model_file = os.path.join(
-            pkg_path,
-            './models/mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite')
-        super(EdgeTPUPanoramaFaceDetector, self).__init__(
-            model_file, None, namespace)
+        super(EdgeTPUPanoramaFaceDetector, self).__init__(None, namespace)
 
         # only for human face
         self.label_ids = [0]

--- a/python/coral_usb/face_detector.py
+++ b/python/coral_usb/face_detector.py
@@ -1,5 +1,3 @@
-import os
-
 from dynamic_reconfigure.server import Server
 
 from coral_usb.cfg import EdgeTPUFaceDetectorConfig
@@ -9,7 +7,9 @@ from coral_usb.detector_base import EdgeTPUPanoramaDetectorBase
 
 class EdgeTPUFaceDetector(EdgeTPUDetectorBase):
     def __init__(self, namespace='~'):
-        super(EdgeTPUFaceDetector, self).__init__(None, namespace)
+        model_file = 'package://coral_usb/models/' + \
+            'mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite'
+        super(EdgeTPUFaceDetector, self).__init__(model_file, None, namespace)
 
         # only for human face
         self.label_ids = [0]
@@ -26,7 +26,10 @@ class EdgeTPUFaceDetector(EdgeTPUDetectorBase):
 
 class EdgeTPUPanoramaFaceDetector(EdgeTPUPanoramaDetectorBase):
     def __init__(self, namespace='~'):
-        super(EdgeTPUPanoramaFaceDetector, self).__init__(None, namespace)
+        model_file = 'package://coral_usb/models/' + \
+            'mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite'
+        super(EdgeTPUPanoramaFaceDetector, self).__init__(
+            model_file, None, namespace)
 
         # only for human face
         self.label_ids = [0]

--- a/python/coral_usb/face_detector.py
+++ b/python/coral_usb/face_detector.py
@@ -7,9 +7,7 @@ from coral_usb.detector_base import EdgeTPUPanoramaDetectorBase
 
 class EdgeTPUFaceDetector(EdgeTPUDetectorBase):
     def __init__(self, namespace='~'):
-        model_file = 'package://coral_usb/models/' + \
-            'mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite'
-        super(EdgeTPUFaceDetector, self).__init__(model_file, None, namespace)
+        super(EdgeTPUFaceDetector, self).__init__(None, None, namespace)
 
         # only for human face
         self.label_ids = [0]
@@ -26,10 +24,8 @@ class EdgeTPUFaceDetector(EdgeTPUDetectorBase):
 
 class EdgeTPUPanoramaFaceDetector(EdgeTPUPanoramaDetectorBase):
     def __init__(self, namespace='~'):
-        model_file = 'package://coral_usb/models/' + \
-            'mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite'
         super(EdgeTPUPanoramaFaceDetector, self).__init__(
-            model_file, None, namespace)
+            None, None, namespace)
 
         # only for human face
         self.label_ids = [0]

--- a/python/coral_usb/human_pose_estimator.py
+++ b/python/coral_usb/human_pose_estimator.py
@@ -18,7 +18,6 @@ from edgetpu.basic.edgetpu_utils import EDGE_TPU_STATE_ASSIGNED
 from edgetpu.basic.edgetpu_utils import EDGE_TPU_STATE_NONE
 from edgetpu.basic.edgetpu_utils import ListEdgeTpuPaths
 from resource_retriever import get_filename
-import rospkg
 import rospy
 
 from coral_usb.util import get_panorama_slices
@@ -48,15 +47,12 @@ class EdgeTPUHumanPoseEstimator(ConnectionBasedTransport):
         rospy.loginfo("Using transport {}".format(self.transport_hint))
 
         super(EdgeTPUHumanPoseEstimator, self).__init__()
-        rospack = rospkg.RosPack()
-        pkg_path = rospack.get_path('coral_usb')
         self.bridge = CvBridge()
         self.classifier_name = rospy.get_param(
             namespace + 'classifier_name', rospy.get_name())
-        model_file = os.path.join(
-            pkg_path,
-            './python/coral_usb/posenet/models/mobilenet/'
-            'posenet_mobilenet_v1_075_481_641_quant_decoder_edgetpu.tflite')
+        model_file = 'package://coral_usb/python/coral_usb/posenet/' + \
+            'models/mobilenet/' + \
+            'posenet_mobilenet_v1_075_481_641_quant_decoder_edgetpu.tflite'
         model_file = rospy.get_param(namespace + 'model_file', model_file)
         if model_file is not None:
             self.model_file = get_filename(model_file, False)

--- a/python/coral_usb/object_detector.py
+++ b/python/coral_usb/object_detector.py
@@ -7,12 +7,7 @@ from coral_usb.detector_base import EdgeTPUPanoramaDetectorBase
 
 class EdgeTPUObjectDetector(EdgeTPUDetectorBase):
     def __init__(self, namespace='~'):
-        model_path = 'package://coral_usb/models/'
-        model_file = model_path + \
-            'mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite'
-        label_file = model_path + 'coco_labels.txt'
-        super(EdgeTPUObjectDetector, self).__init__(
-            model_file, label_file, namespace)
+        super(EdgeTPUObjectDetector, self).__init__(None, None, namespace)
 
         # dynamic reconfigure
         dyn_namespace = namespace
@@ -25,12 +20,8 @@ class EdgeTPUObjectDetector(EdgeTPUDetectorBase):
 
 class EdgeTPUPanoramaObjectDetector(EdgeTPUPanoramaDetectorBase):
     def __init__(self, namespace='~'):
-        model_path = 'package://coral_usb/models/'
-        model_file = model_path + \
-            'mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite'
-        label_file = model_path + 'coco_labels.txt'
         super(EdgeTPUPanoramaObjectDetector, self).__init__(
-            model_file, label_file, namespace)
+            None, None, namespace)
 
         # dynamic reconfigure
         dyn_namespace = namespace

--- a/python/coral_usb/object_detector.py
+++ b/python/coral_usb/object_detector.py
@@ -1,7 +1,6 @@
 import os
 
 from dynamic_reconfigure.server import Server
-import rospkg
 
 from coral_usb.cfg import EdgeTPUObjectDetectorConfig
 from coral_usb.detector_base import EdgeTPUDetectorBase
@@ -10,10 +9,7 @@ from coral_usb.detector_base import EdgeTPUPanoramaDetectorBase
 
 class EdgeTPUObjectDetector(EdgeTPUDetectorBase):
     def __init__(self, namespace='~'):
-        rospack = rospkg.RosPack()
-        pkg_path = rospack.get_path('coral_usb')
-        super(EdgeTPUObjectDetector, self).__init__(
-            namespace)
+        super(EdgeTPUObjectDetector, self).__init__(namespace)
 
         # dynamic reconfigure
         dyn_namespace = namespace
@@ -26,14 +22,7 @@ class EdgeTPUObjectDetector(EdgeTPUDetectorBase):
 
 class EdgeTPUPanoramaObjectDetector(EdgeTPUPanoramaDetectorBase):
     def __init__(self, namespace='~'):
-        rospack = rospkg.RosPack()
-        pkg_path = rospack.get_path('coral_usb')
-        model_file = os.path.join(
-            pkg_path,
-            './models/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite')
-        label_file = os.path.join(pkg_path, './models/coco_labels.txt')
-        super(EdgeTPUPanoramaObjectDetector, self).__init__(
-            model_file, label_file, namespace)
+        super(EdgeTPUPanoramaObjectDetector, self).__init__(namespace)
 
         # dynamic reconfigure
         dyn_namespace = namespace

--- a/python/coral_usb/object_detector.py
+++ b/python/coral_usb/object_detector.py
@@ -12,12 +12,8 @@ class EdgeTPUObjectDetector(EdgeTPUDetectorBase):
     def __init__(self, namespace='~'):
         rospack = rospkg.RosPack()
         pkg_path = rospack.get_path('coral_usb')
-        model_file = os.path.join(
-            pkg_path,
-            './models/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite')
-        label_file = os.path.join(pkg_path, './models/coco_labels.txt')
         super(EdgeTPUObjectDetector, self).__init__(
-            model_file, label_file, namespace)
+            namespace)
 
         # dynamic reconfigure
         dyn_namespace = namespace

--- a/python/coral_usb/object_detector.py
+++ b/python/coral_usb/object_detector.py
@@ -1,5 +1,3 @@
-import os
-
 from dynamic_reconfigure.server import Server
 
 from coral_usb.cfg import EdgeTPUObjectDetectorConfig
@@ -9,7 +7,11 @@ from coral_usb.detector_base import EdgeTPUPanoramaDetectorBase
 
 class EdgeTPUObjectDetector(EdgeTPUDetectorBase):
     def __init__(self, namespace='~'):
-        super(EdgeTPUObjectDetector, self).__init__(namespace)
+        model_file = 'package://coral_usb/models/' + \
+            'mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite'
+        label_file = 'package://coral_usb/models/coco_labels.txt'
+        super(EdgeTPUObjectDetector, self).__init__(
+            model_file, label_file, namespace)
 
         # dynamic reconfigure
         dyn_namespace = namespace
@@ -22,7 +24,11 @@ class EdgeTPUObjectDetector(EdgeTPUDetectorBase):
 
 class EdgeTPUPanoramaObjectDetector(EdgeTPUPanoramaDetectorBase):
     def __init__(self, namespace='~'):
-        super(EdgeTPUPanoramaObjectDetector, self).__init__(namespace)
+        model_file = 'package://coral_usb/models/' + \
+            'mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite'
+        label_file = 'package://coral_usb/models/coco_labels.txt'
+        super(EdgeTPUPanoramaObjectDetector, self).__init__(
+            model_file, label_file, namespace)
 
         # dynamic reconfigure
         dyn_namespace = namespace

--- a/python/coral_usb/object_detector.py
+++ b/python/coral_usb/object_detector.py
@@ -7,9 +7,10 @@ from coral_usb.detector_base import EdgeTPUPanoramaDetectorBase
 
 class EdgeTPUObjectDetector(EdgeTPUDetectorBase):
     def __init__(self, namespace='~'):
-        model_file = 'package://coral_usb/models/' + \
+        model_path = 'package://coral_usb/models/'
+        model_file = model_path + \
             'mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite'
-        label_file = 'package://coral_usb/models/coco_labels.txt'
+        label_file = model_path + 'coco_labels.txt'
         super(EdgeTPUObjectDetector, self).__init__(
             model_file, label_file, namespace)
 
@@ -24,9 +25,10 @@ class EdgeTPUObjectDetector(EdgeTPUDetectorBase):
 
 class EdgeTPUPanoramaObjectDetector(EdgeTPUPanoramaDetectorBase):
     def __init__(self, namespace='~'):
-        model_file = 'package://coral_usb/models/' + \
+        model_path = 'package://coral_usb/models/'
+        model_file = model_path + \
             'mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite'
-        label_file = 'package://coral_usb/models/coco_labels.txt'
+        label_file = model_path + 'coco_labels.txt'
         super(EdgeTPUPanoramaObjectDetector, self).__init__(
             model_file, label_file, namespace)
 

--- a/python/coral_usb/semantic_segmenter.py
+++ b/python/coral_usb/semantic_segmenter.py
@@ -20,7 +20,6 @@ from edgetpu.basic.edgetpu_utils import EDGE_TPU_STATE_ASSIGNED
 from edgetpu.basic.edgetpu_utils import EDGE_TPU_STATE_NONE
 from edgetpu.basic.edgetpu_utils import ListEdgeTpuPaths
 from resource_retriever import get_filename
-import rospkg
 import rospy
 
 from coral_usb.util import get_panorama_slices
@@ -39,14 +38,11 @@ class EdgeTPUSemanticSegmenter(ConnectionBasedTransport):
         rospy.loginfo("Using transport {}".format(self.transport_hint))
 
         super(EdgeTPUSemanticSegmenter, self).__init__()
-        rospack = rospkg.RosPack()
-        pkg_path = rospack.get_path('coral_usb')
         self.bridge = CvBridge()
         self.classifier_name = rospy.get_param(
             namespace + 'classifier_name', rospy.get_name())
-        model_file = os.path.join(
-            pkg_path,
-            './models/deeplabv3_mnv2_pascal_quant_edgetpu.tflite')
+        model_file = 'package://coral_usb/models/' + \
+            'deeplabv3_mnv2_pascal_quant_edgetpu.tflite'
         model_file = rospy.get_param(namespace + 'model_file', model_file)
         label_file = rospy.get_param(namespace + 'label_file', None)
         if model_file is not None:


### PR DESCRIPTION
First, I changed the way model file and label file are specified for object detector.

Originally, they are parameters launching from the beginning. But I wonder they can be changed during launching. 
For example, originally, the robot loads them at startup. When we want to use our custom model file, we have to restart robot and it is troublesome.
 
With the help of this PR, we can dynamically change the model file and label file even while the robot launching.



I also change the way model file are specified for face detector. 
I need to change `detector_base.py` for object detector. 
Since both `object_detector.py` and `face_detector.py` are based on `detector_base.py`, the way model file (and label file) are loaded should be the same for both.