### PR TITLE
Support objects in boundary gap of panorama image

### DIFF
--- a/python/coral_usb/detector_base.py
+++ b/python/coral_usb/detector_base.py
@@ -289,7 +289,12 @@ class EdgeTPUPanoramaDetectorBase(EdgeTPUDetectorBase):
         labels = []
         scores = []
         for panorama_slice in panorama_slices:
-            img = orig_img[:, panorama_slice, :]
+            if panorama_slice.start < panorama_slice.stop:
+                left_sliced_img = orig_img[:, panorama_slice.start:, :]
+                right_sliced_img = orig_img[:, :panorama_slice.stop, :]
+                img = np.concatenate([left_sliced_img, right_sliced_img], 1)
+            else:
+                img = orig_img[:, panorama_slice, :]
             bbox, label, score = self._detect_step(
                 img, x_offset=panorama_slice.start)
             bboxes.append(bbox)

--- a/python/coral_usb/detector_base.py
+++ b/python/coral_usb/detector_base.py
@@ -289,7 +289,7 @@ class EdgeTPUPanoramaDetectorBase(EdgeTPUDetectorBase):
         labels = []
         scores = []
         for panorama_slice in panorama_slices:
-            if panorama_slice.start < panorama_slice.stop:
+            if panorama_slice.start > panorama_slice.stop:
                 left_sliced_img = orig_img[:, panorama_slice.start:, :]
                 right_sliced_img = orig_img[:, :panorama_slice.stop, :]
                 img = np.concatenate([left_sliced_img, right_sliced_img], 1)

--- a/python/coral_usb/util.py
+++ b/python/coral_usb/util.py
@@ -9,4 +9,4 @@ def get_panorama_slices(width, n_split, overlap=True):
         x_offsets = np.arange(n_split) * int(width / n_split)
         x_width = int(width / n_split)
     x_offsets = x_offsets.astype(np.int)
-    return [slice(x_offset, x_offset + x_width) for x_offset in x_offsets]
+    return [slice(x_offset, x_offset + x_width if x_offset + x_width <= width else x_offset + x_width - width) for x_offset in x_offsets]

--- a/python/coral_usb/util.py
+++ b/python/coral_usb/util.py
@@ -5,8 +5,13 @@ def get_panorama_slices(width, n_split, overlap=True):
     if overlap:
         x_offsets = np.arange(n_split) * int(width / (n_split + 1))
         x_width = int(2 * width / (n_split + 1))
+        x_offsets = x_offsets.astype(np.int)
+        panorama_slices = [slice(x_offset, x_offset + x_width) for x_offset in x_offsets]
+        panorama_slices.append(slice(width - int(x_width/2), int(x_width/2)))
+        return panorama_slices
     else:
         x_offsets = np.arange(n_split) * int(width / n_split)
         x_width = int(width / n_split)
-    x_offsets = x_offsets.astype(np.int)
-    return [slice(x_offset, x_offset + x_width if x_offset + x_width <= width else x_offset + x_width - width) for x_offset in x_offsets]
+        x_offsets = x_offsets.astype(np.int)
+        panorama_slices = [slice(x_offset, x_offset + x_width) for x_offset in x_offsets]
+        return panorama_slices


### PR DESCRIPTION
Current panorama_object_detector does not support objects in boundary gap of panorama image ( object overlap left side and righ side of image)
This PR will make it possible to support it