### PR TITLE
use package:// instead of find

### DIFF
--- a/launch/edgetpu_face_detector.launch
+++ b/launch/edgetpu_face_detector.launch
@@ -2,7 +2,8 @@
   <arg name="nodename" default="edgetpu_face_detector"/>
   <arg name="INPUT_IMAGE"/>
   <arg name="IMAGE_TRANSPORT" default="raw"/>
-  <arg name="model_file" default="$(find coral_usb)/models/mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite"/>
+  <arg name="model_file"
+       default="package://coral_usb/models/mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite"/>
   <arg name="device_id" default="0" />
 
   <node name="$(arg nodename)"

--- a/launch/edgetpu_human_pose_estimator.launch
+++ b/launch/edgetpu_human_pose_estimator.launch
@@ -2,7 +2,8 @@
   <arg name="nodename" default="edgetpu_human_pose_estimator"/>
   <arg name="INPUT_IMAGE"/>
   <arg name="IMAGE_TRANSPORT" default="raw"/>
-  <arg name="model_file" default="$(find coral_usb)/python/coral_usb/posenet/models/mobilenet/posenet_mobilenet_v1_075_481_641_quant_decoder_edgetpu.tflite"/>
+  <arg name="model_file"
+       default="package://coral_usb/python/coral_usb/posenet/models/mobilenet/posenet_mobilenet_v1_075_481_641_quant_decoder_edgetpu.tflite"/>
   <arg name="device_id" default="0" />
 
   <node name="$(arg nodename)"

--- a/launch/edgetpu_node_manager.launch
+++ b/launch/edgetpu_node_manager.launch
@@ -1,6 +1,7 @@
 <launch>
   <arg name="INPUT_IMAGE"/>
-  <arg name="YAML_PATH" default="$(find coral_usb)/launch/edgetpu_node_manager_params.yaml" />
+  <arg name="YAML_PATH"
+       default="package://coral_usb/launch/edgetpu_node_manager_params.yaml" />
 
   <rosparam command="load" file="$(arg YAML_PATH)" />
   <node name="edgetpu_node_manager"

--- a/launch/edgetpu_object_detector.launch
+++ b/launch/edgetpu_object_detector.launch
@@ -2,8 +2,10 @@
   <arg name="nodename" default="edgetpu_object_detector"/>
   <arg name="INPUT_IMAGE"/>
   <arg name="IMAGE_TRANSPORT" default="raw"/>
-  <arg name="model_file" default="$(find coral_usb)/models/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite"/>
-  <arg name="label_file" default="$(find coral_usb)/models/coco_labels.txt"/>
+  <arg name="model_file"
+       default="package://coral_usb/models/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite"/>
+  <arg name="label_file"
+       default="package://coral_usb/models/coco_labels.txt"/>
   <arg name="device_id" default="0" />
 
   <node name="$(arg nodename)"

--- a/launch/edgetpu_panorama_face_detector.launch
+++ b/launch/edgetpu_panorama_face_detector.launch
@@ -2,7 +2,8 @@
   <arg name="nodename" default="edgetpu_panorama_face_detector"/>
   <arg name="INPUT_IMAGE"/>
   <arg name="IMAGE_TRANSPORT" default="raw"/>
-  <arg name="model_file" default="$(find coral_usb)/models/mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite"/>
+  <arg name="model_file"
+       default="package://coral_usb/models/mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite"/>
   <arg name="device_id" default="0" />
   <arg name="n_split" default="3" />
   <arg name="overlap" default="true" />

--- a/launch/edgetpu_panorama_human_pose_estimator.launch
+++ b/launch/edgetpu_panorama_human_pose_estimator.launch
@@ -2,7 +2,8 @@
   <arg name="nodename" default="edgetpu_panorama_human_pose_estimator"/>
   <arg name="INPUT_IMAGE"/>
   <arg name="IMAGE_TRANSPORT" default="raw"/>
-  <arg name="model_file" default="$(find coral_usb)/python/coral_usb/posenet/models/mobilenet/posenet_mobilenet_v1_075_481_641_quant_decoder_edgetpu.tflite"/>
+  <arg name="model_file"
+       default="package://coral_usb/python/coral_usb/posenet/models/mobilenet/posenet_mobilenet_v1_075_481_641_quant_decoder_edgetpu.tflite"/>
   <arg name="device_id" default="0" />
   <arg name="n_split" default="3" />
   <arg name="overlap" default="true" />

--- a/launch/edgetpu_panorama_object_detector.launch
+++ b/launch/edgetpu_panorama_object_detector.launch
@@ -2,8 +2,10 @@
   <arg name="nodename" default="edgetpu_panorama_object_detector"/>
   <arg name="INPUT_IMAGE"/>
   <arg name="IMAGE_TRANSPORT" default="raw"/>
-  <arg name="model_file" default="$(find coral_usb)/models/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite"/>
-  <arg name="label_file" default="$(find coral_usb)/models/coco_labels.txt"/>
+  <arg name="model_file"
+       default="package://coral_usb/models/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite"/>
+  <arg name="label_file"
+       default="package://coral_usb/models/coco_labels.txt"/>
   <arg name="device_id" default="0" />
   <arg name="n_split" default="3" />
   <arg name="overlap" default="true" />


### PR DESCRIPTION
use `package://` instead of `find` to prevent `rosparam set` with absolute path from remote computers.

cc. @708yamaguchi 