### PR TITLE
downgrade edgetpu-compiler to be 14.1

### DIFF
--- a/training/epic_kitchens_55/Dockerfile
+++ b/training/epic_kitchens_55/Dockerfile
@@ -64,10 +64,11 @@ RUN apt-get update && \
 # install gdown
 RUN pip install gdown
 
-# install edgetpu compiler
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | tee /etc/apt/sources.list.d/coral-edgetpu.list && \
-    apt-get update && apt-get install -y edgetpu-compiler
+# install edgetpu compiler 14.1
+RUN gdown https://drive.google.com/uc?id=1vgy3vTqhfQ5kedQLF1NzegDbw25LbAkb && \
+    dpkg -i libedgetpu1-std_14.1_amd64.deb
+RUN wget -O edgetpu-compiler_14.1_amd64.deb https://packages.cloud.google.com/apt/pool/edgetpu-compiler_14.1_amd64_ef6eef29200270dcb941d2c1defa39c7d80e9c6f30cf7ced1c653a30bde0a502.deb && \
+    dpkg -i edgetpu-compiler_14.1_amd64.deb
 
 # install tree
 RUN apt-get install -y tree

--- a/training/labelme_voc/Dockerfile
+++ b/training/labelme_voc/Dockerfile
@@ -64,10 +64,11 @@ RUN apt-get update && \
 # install gdown
 RUN pip install gdown
 
-# install edgetpu compiler
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | tee /etc/apt/sources.list.d/coral-edgetpu.list && \
-    apt-get update && apt-get install -y edgetpu-compiler
+# install edgetpu compiler 14.1
+RUN gdown https://drive.google.com/uc?id=1vgy3vTqhfQ5kedQLF1NzegDbw25LbAkb && \
+    dpkg -i libedgetpu1-std_14.1_amd64.deb
+RUN wget -O edgetpu-compiler_14.1_amd64.deb https://packages.cloud.google.com/apt/pool/edgetpu-compiler_14.1_amd64_ef6eef29200270dcb941d2c1defa39c7d80e9c6f30cf7ced1c653a30bde0a502.deb && \
+    dpkg -i edgetpu-compiler_14.1_amd64.deb
 
 # install tree
 RUN apt-get install -y tree


### PR DESCRIPTION
`edgetpu-compiler` `14.1` instead of latest `16.0` [from debian](https://github.com/knorth55/coral_usb_ros/blob/master/training/labelme_voc/Dockerfile#L70) is forced to be installed, reasons are:
- If using `16.0`, loading tpu model file with `coral_usb_ros` will fail with output `RuntimeError: Failed to prepare for TPU. Failed precondition: Package requires runtime version (14), which is newer than this runtime version (13).Node number 0 (edgetpu-custom-op) failed to prepare` as [this instruction](https://coral.ai/docs/edgetpu/compiler/#compiler-and-runtime-versions).
- Tpu model file from `16.0` compiler requires [runtime 14](https://coral.ai/docs/edgetpu/compiler/#compiler-and-runtime-versions), however [runtime installation](https://github.com/knorth55/coral_usb_ros#install-the-edge-tpu-runtime) in `coral_usb_ros`  with [deprecated](https://coral.ai/software/#debian-packages) `python3-edgetpu` only supports runtime 13.
- `edgetpu-compiler` being `14.1` in the previous dlbox3 image works well without problem, therefore we choose `14.1` instead of `15.0`.

The modification has been verified with `labelme_voc` demo without problem.
