### PR TITLE
Fix package name in labelimg docs

### DIFF
--- a/training/labelimg_voc/README.md
+++ b/training/labelimg_voc/README.md
@@ -9,7 +9,7 @@ Please follow [here](https://tensorflow-object-detection-api-tutorial.readthedoc
 Then, you need to build docker image called `train-edgetpu-object-detection-xml`.
 
 ```bash
-roscd coral_usb_ros/training/labelimg_voc
+roscd coral_usb/training/labelimg_voc
 make
 ```
 
@@ -18,7 +18,7 @@ make
 Finally, you can train the model with your dataset.
 
 ```bash
-roscd coral_usb_ros/training/labelimg_voc
+roscd coral_usb/training/labelimg_voc
 bash ./run.sh <your_dataset_path>
 ```
 
@@ -34,6 +34,6 @@ You can visualize your training result with TensorBoard.
 TensorBoard port is often set around `6006`.
 
 ```bash
-roscd coral_usb_ros/training/labelimg_voc
+roscd coral_usb/training/labelimg_voc
 bash ./run.sh <your_dataset_path> --port <port> tensorboard
 ```


### PR DESCRIPTION
The name of the ROS package is `coral_usb`, not `coral_usb_ros` thus I fixed the document.