### PR TITLE
Add diagnostics for python3 compatibility

### DIFF
--- a/fc.rosinstall
+++ b/fc.rosinstall
@@ -3,6 +3,10 @@
     uri: https://github.com/knorth55/coral_usb_ros.git
     version: pr2
 - git:
+    local-name: diagnostics
+    uri: https://github.com/ros/diagnostics
+    version: 1.9.4
+- git:
     local-name: jsk_common
     uri: https://github.com/jsk-ros-pkg/jsk_common.git
     version: master


### PR DESCRIPTION
Since diagnostics updater uses a version that does not support python3, the following error will be displayed when using the latest jsk_common.

```
remote[c2-0]:  import likely_packaged, get_recent_crashes
  File "/usr/lib/python3/dist-packages/apport/__init__.py", line 5, in <module>
    from apport.report import Report
  File "/usr/lib/python3/dist-packages/apport/report.py", line 30, in <module>
    import apport.fileutils
  File "/usr/lib/python3/dist-packages/apport/fileutils.py", line 23, in <module>
    from apport.packaging_impl import impl as packaging
  File "/usr/lib/python3/dist-packages/apport/packaging_impl.py", line 20, in <module>
    import apt
  File "/usr/lib/python3/dist-packages/apt/__init__.py", line 23, in <module>
    import apt_pkg
ImportError: No module named 'apt_pkg'

Original exception was:
Traceback (most recent call last):
  File "/home/applications/ros/coral_ws/src/coral_usb_ros/node_scripts/edgetpu_human_pose_estimator.py", line 5, in <module>
    from coral_usb.human_pose_estimator import EdgeTPUHumanPoseEstimator
  File "/home/applications/ros/coral_ws/src/coral_usb_ros/python/coral_usb/human_pose_estimator.py", line 32, in <module>
    from jsk_topic_tools import ConnectionBasedTransport
  File "/home/applications/ros/indigo/devel/lib/python2.7/dist-packages/jsk_topic_tools/__init__.py", line 35, in <module>
    exec(__fh.read())
  File "<string>", line 4, in <module>
  File "/home/applications/ros/indigo/src/jsk-ros-pkg/jsk_common/jsk_topic_tools/src/jsk_topic_tools/timered_diagnostic_updater.py", line 3, in <module>
    import diagnostic_updater
  File "/opt/ros/indigo/lib/python2.7/dist-packages/diagnostic_updater/__init__.py", line 37, in <module>
    from ._diagnostic_updater import *
  File "/opt/ros/indigo/lib/python2.7/dist-packages/diagnostic_updater/_diagnostic_updater.py", line 40, in <module>
    import threading, httplib
ImportError: No module named 'httplib'
[edgetpu_human_pose_estimator-1] process has died [pid 20301, exit code 1, cmd /home/applications/ros/coral_ws/devel/lib/coral_usb/edgetpu_human_pose_estimator.py ~input:=/kinect_head/rgb/image_rect_color __name:=edgetpu_human_pose_estimator __log:=/home/applicati
remote[c2-0]: ons/.ros/log/3ec9bcb6-e196-11ec-a2b3-d05099c29feb/edgetpu_human_pose_estimator-1.log].
log file: /home/applications/.ros/log/3ec9bcb6-e196-11ec-a2b3-d05099c29feb/edgetpu_human_pose_estimator-1*.log
Traceback (most recent call last):
  File "/home/applications/ros/coral_ws/src/coral_usb_ros/node_scripts/edgetpu_human_pose_estimator.py", line 5, in <module>
    from coral_usb.human_pose_estimator import EdgeTPUHumanPoseEstimator
  File "/home/applications/ros/coral_ws/src/coral_usb_ros/python/coral_usb/human_pose_estimator.py", line 32, in <module>
    from jsk_topic_tools import ConnectionBasedTransport
  File "/home/applications/ros/indigo/devel/lib/python2.7/dist-packages/jsk_topic_tools/__init__.py", line 35, in <module>
    exec(__fh.read())
  File "<string>", line 4, in <module>
  File "/home/applications/ros/indigo/src/jsk-ros-pkg/jsk_common/jsk_topic_tools/src/jsk_topic_tools/timered_diagnostic_updater.py", line 3, in <module>
    import diagnostic_updater
  File "/opt/ros/indigo/lib/python2.7/dist-packages/diagnostic_updater/__init__.py", line 37, in <module>
    from ._diagnostic_updater import *
  File "/opt/ros/indigo/lib/python2.7/dist-packages/diagnostic_updater/_diagnostic_updater.py", line 40, in <module>
    import threading, httplib
ImportError: No module named 'httplib'
Error in sys.excepthook:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/apport_python_hook.py", line 63, in apport_excepthook
    from apport.fileutils import likely_packaged, get_recent_crashes
  File "/usr/lib/python3/dist-packages/apport/__init__.py", line 5, in <module>
    from apport.report import Report
  File "/usr/lib/python3/dist-packages/apport/report.py", line 30, in <module>
    import apport.fileutils
  File "/usr/lib/python3/dist-packages/apport/fileutils.py", line 23, in <module>
    from apport.packaging_impl import impl as packaging
  File "/usr/lib/python3/dist-packages/apport/packaging_impl.py", line 20, in <module>
    import apt
  File "/usr/lib/python3/dist-packages/apt/__init_
[c2-0]: [edgetpu_human_pose_estimator-1] process has died [pid 20356, exit code 1, cmd /home/applications/ros/coral_ws/devel/lib/coral_usb/edgetpu_human_pose_estimator.py ~input:=/kinect_head/rgb/image_rect_color __name:=edgetpu_human_pose_estimator __log:=/home/applications/.ros/log/3ec9bcb6-e196-11ec-a2b3-d05099c29feb/edgetpu_human_pose_estimator-1.log].
l```
